### PR TITLE
fix(model): correctly parse tau flag from LCN sentence files

### DIFF
--- a/lcn/model.py
+++ b/lcn/model.py
@@ -892,7 +892,11 @@ class LCN:
             tau = False
             if ";" in line:
                 pos = line.find(";")
-                tau = bool(line[pos+1:].strip())
+                tau_str = line[pos+1:].strip()
+                # Parse "tau=true" or "tau=false" correctly — bool() of any
+                # non-empty string (including "False") returns True, so we
+                # must split on "=" to get the actual boolean value.
+                tau = tau_str.split("=")[1].lower() == 'true'
                 line = line[:pos]
 
             # Get the lower and upper bounds


### PR DESCRIPTION
Fixes #5

**Bug:** The `from_lcn()` parser in `lcn/model.py` used `bool(string)` to parse the `tau` flag. In Python, `bool("False")` returns `True` because any non-empty string is truthy. This meant writing `; tau=False` in a sentence file silently set `tau = True`.

**Fix:** Split the value on `"="` and compare with `"true"` instead of using `bool()`.

Example — before:
```
s1: [0.5 <= P(A) <= 0.8 | ; tau=False]   # tau was True (WRONG)
```

After:
```
s1: [0.5 <= P(A) <= 0.8 | ; tau=False]   # tau is False (correct)